### PR TITLE
Fix rank calculation in DDSketch::quantile()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,6 @@ exclude = [".gitignore"]
 [dependencies]
 
 [dev-dependencies]
+approx = "0.5.1"
 rand = "0.7.2"
 rand_distr = "0.2.2"


### PR DESCRIPTION
The rank calculation in DDSketch::quantile() is changed to 'ceiling(q *
count)'. Previously, the rank was calculated as 'floor(q * (count - 1) +
1)'. The 'floor' was implicit due to the f64 -> u64 conversion.

The previous method could be off by 1 in some cases. Consider q = 0.6
and count = 4, which should correspond to a rank of 3. We would instead
get floor(0.6 * (4-1) + 1) = floor(1.8 + 1) = 2.

The error is not obvious at high counts, but pronounced when there are
few elements in the sketch or when the difference in value between two
consecutive ranks is high.

A new test case is added, which passes with the new rank calculation.