### PR TITLE
Fix merge by mirroring python implementation

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -39,21 +39,29 @@ impl Config {
         Self::new(DEFAULT_ALPHA, DEFAULT_MAX_BINS, DEFAULT_MIN_VALUE)
     }
 
-    pub fn key(self: &Self, v: f64) -> i32 {
-        if v < -self.min_value {
-            return -(self.log_gamma(-v).ceil() as i32) - self.offset;
-        } else if v > self.min_value {
-            return (self.log_gamma(v).ceil() as i32) + self.offset;
-        } else {
-            return 0;
-        }
+    pub fn key(&self, v: f64) -> i32 {
+        self.log_gamma(v).ceil() as i32
     }
 
-    pub fn log_gamma(self: &Self, value: f64) -> f64 {
+    pub fn value(&self, key: i32) -> f64 {
+        self.pow_gamma(key) * (2.0 / (1.0 + self.gamma))
+    }
+
+    pub fn log_gamma(&self, value: f64) -> f64 {
         log_gamma(value, self.gamma_ln)
     }
 
-    pub fn pow_gamma(self: &Self, k: i32) -> f64 {
-        ((k as f64) * self.gamma_ln).exp()
+    pub fn pow_gamma(&self, key: i32) -> f64 {
+        ((key as f64) * self.gamma_ln).exp()
+    }
+
+    pub fn min_possible(&self) -> f64 {
+        self.min_value
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self::new(DEFAULT_ALPHA, DEFAULT_MAX_BINS, DEFAULT_MIN_VALUE)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,8 @@ d.add(1.0);
 
 let q = d.quantile(0.50).unwrap();
 
-assert_eq!(q, Some(1.0));
+assert!(q < Some(1.01));
+assert!(q > Some(0.99));
 ```
 
 Sketches can also be merged.


### PR DESCRIPTION
This is a fix for panics during merge.  I wasn't sure how to fix the existing code, so I made this larger change based on the python CollapsingLowestDenseStore implementation.  Part of this included adding a special zero bin and a separate store for negative values.

While this is a much larger change than I would like, there are some advantages to this approach.  Results will more closely match other implementations and we can verify against expected values from the python implementation.

closes #4