### PR TITLE
Bump `rand` dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ serde = { package = "serde", version = "1.0", optional = true, features = ["deri
 
 [dev-dependencies]
 approx = "0.5.1"
-rand = "0.7.2"
-rand_distr = "0.2.2"
+rand = "0.8.5"
+rand_distr = "0.4.3"
 
 [features]
 use_serde = ["serde", "serde/derive"]


### PR DESCRIPTION
Trying to package this project as part of a dependency chain in Fedora. It seems this version bump does not change much.

It is not very urgent to include and ship this change since we can make these 2 changes downstream as well, so feel free to decide when you want to bump these dependencies.