### PR TITLE
Add DDSketch::add_with_count: constant-time weighted add

### DIFF
--- a/src/ddsketch.rs
+++ b/src/ddsketch.rs
@@ -1,3 +1,4 @@
+use std::convert::TryFrom;
 use std::{error, fmt};
 
 #[cfg(feature = "use_serde")]
@@ -68,14 +69,31 @@ impl DDSketch {
 
     /// Add the sample to the sketch
     pub fn add(&mut self, v: f64) {
+        self.add_with_count(v, 1);
+    }
+
+    /// Add the sample to the sketch `count` times, as if `add(v)` had been
+    /// called `count` times, in constant time.
+    ///
+    /// Mirrors the `count` parameter of DataDog's other DDSketch
+    /// implementations (Java's `accept(value, count)`, Go's `AddWithCount`),
+    /// restricted to integer counts to match this crate's integer bin counts.
+    ///
+    /// Adding with a count of zero is a no-op: it records nothing and leaves
+    /// min/max/sum untouched.
+    pub fn add_with_count(&mut self, v: f64, count: u64) {
+        if count == 0 {
+            return;
+        }
+
         if v > self.config.min_possible() {
             let key = self.config.key(v);
-            self.store.add(key);
+            self.store.add_count(key, count);
         } else if v < -self.config.min_possible() {
             let key = self.config.key(-v);
-            self.negative_store.add(key);
+            self.negative_store.add_count(key, count);
         } else {
-            self.zero_count += 1;
+            self.zero_count += count;
         }
 
         if v < self.min {
@@ -84,7 +102,7 @@ impl DDSketch {
         if self.max < v {
             self.max = v;
         }
-        self.sum += v;
+        self.sum += v * (count as f64);
     }
 
     /// Return the quantile value for quantiles between 0.0 and 1.0. Result is an error, represented
@@ -106,7 +124,9 @@ impl DDSketch {
             return Ok(Some(self.max));
         }
 
-        let rank = (q * (self.count() as f64 - 1.0)) as u64;
+        // Rank math stays in u64: `count()` narrows to usize, which truncates
+        // on 32-bit targets once weighted adds push the total past 2^32.
+        let rank = (q * (self.total_count() as f64 - 1.0)) as u64;
         let quantile;
         if rank < self.negative_store.count() {
             let reversed_rank = self.negative_store.count() - rank - 1;
@@ -151,9 +171,15 @@ impl DDSketch {
         }
     }
 
-    /// Returns the number of values added to the sketch
+    /// Returns the number of values added to the sketch, saturating at
+    /// `usize::MAX` on targets where `usize` is narrower than the internal
+    /// 64-bit count.
     pub fn count(&self) -> usize {
-        (self.store.count() + self.zero_count + self.negative_store.count()) as usize
+        usize::try_from(self.total_count()).unwrap_or(usize::MAX)
+    }
+
+    fn total_count(&self) -> u64 {
+        self.store.count() + self.zero_count + self.negative_store.count()
     }
 
     /// Returns the length of the underlying `Store`. This is mainly only useful for understanding
@@ -226,6 +252,82 @@ mod tests {
         let c = Config::new(alpha, 2048, 10e-9);
         let mut dd = DDSketch::new(c);
         dd.add(0.0);
+    }
+
+    #[test]
+    fn test_add_with_count_equals_repeated_add() {
+        let c = Config::new(0.01, 2048, 10e-9);
+        let mut repeated = DDSketch::new(c);
+        let mut counted = DDSketch::new(c);
+
+        // Positive, negative, and zero paths, with mixed counts.
+        for (v, n) in [(4.2, 1_000u64), (-7.0, 250), (0.0, 33), (123.45, 1)] {
+            for _ in 0..n {
+                repeated.add(v);
+            }
+            counted.add_with_count(v, n);
+        }
+
+        assert_eq!(repeated.count(), counted.count());
+        assert_eq!(repeated.min(), counted.min());
+        assert_eq!(repeated.max(), counted.max());
+        // Not exactly equal: repeated `+= v` accumulates float rounding that
+        // the single `v * count` multiply avoids.
+        assert_relative_eq!(
+            repeated.sum().unwrap(),
+            counted.sum().unwrap(),
+            max_relative = 1e-9
+        );
+        for q in [0.0, 0.01, 0.25, 0.5, 0.75, 0.99, 1.0] {
+            assert_eq!(
+                repeated.quantile(q).unwrap(),
+                counted.quantile(q).unwrap(),
+                "quantile {q} diverged"
+            );
+        }
+    }
+
+    #[test]
+    fn test_add_with_count_through_store_collapse() {
+        // A tight bin limit plus a wide dynamic range forces the collapsing
+        // store to collapse mid-stream; weighted adds must ride through
+        // collapse identically to repeated adds (collapse depends only on the
+        // key sequence, never on bin counts).
+        let c = Config::new(0.01, 128, 10e-9);
+        let mut repeated = DDSketch::new(c);
+        let mut counted = DDSketch::new(c);
+
+        let mut v = 1.0e-6;
+        let mut n = 1u64;
+        while v < 1.0e12 {
+            for _ in 0..n {
+                repeated.add(v);
+            }
+            counted.add_with_count(v, n);
+            v *= 3.7;
+            n = (n * 7) % 1000 + 1;
+        }
+
+        assert_eq!(repeated.count(), counted.count());
+        for q in [0.01, 0.25, 0.5, 0.75, 0.99] {
+            assert_eq!(
+                repeated.quantile(q).unwrap(),
+                counted.quantile(q).unwrap(),
+                "quantile {q} diverged"
+            );
+        }
+    }
+
+    #[test]
+    fn test_add_with_count_zero_is_noop() {
+        let c = Config::new(0.01, 2048, 10e-9);
+        let mut dd = DDSketch::new(c);
+        dd.add_with_count(42.0, 0);
+
+        assert_eq!(dd.count(), 0);
+        assert_eq!(dd.min(), None);
+        assert_eq!(dd.max(), None);
+        assert_eq!(dd.quantile(0.5).unwrap(), None);
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -45,12 +45,6 @@ impl Store {
         self.bins.is_empty()
     }
 
-    pub fn add(&mut self, key: i32) {
-        let idx = self.get_index(key);
-        self.bins[idx] += 1;
-        self.count += 1;
-    }
-
     /// See Java: https://github.com/DataDog/sketches-java/blob/master/src/main/java/com/datadoghq/sketch/ddsketch/store/DenseStore.java  (add(int index, double count) method)
     pub(crate) fn add_count(&mut self, key: i32, count: u64) {
         let idx = self.get_index(key);
@@ -127,7 +121,7 @@ impl Store {
                     let zero_len = (new_min_key - self.min_key) as usize;
                     self.bins.splice(
                         collapse_start_index..collapse_end_index,
-                        std::iter::repeat_n(0, zero_len),
+                        std::iter::repeat(0).take(zero_len),
                     );
                     self.bins[collapse_end_index] += collapsed_count;
                 }
@@ -237,7 +231,7 @@ mod tests {
         let mut s = Store::new(2048);
 
         for i in 0..2048 {
-            s.add(i);
+            s.add_count(i, 1);
         }
     }
 
@@ -246,7 +240,7 @@ mod tests {
         let mut s = Store::new(2048);
 
         for i in (0..2048).rev() {
-            s.add(i);
+            s.add_count(i, 1);
         }
     }
 }


### PR DESCRIPTION
## Motivation

Adding the same value N times currently requires N `add()` calls — O(N), with no workaround outside the crate. Weighted insertion supports bulk ingestion, sampling-rate compensation, and weighted observations such as time-weighted occupation histograms (record "spent 15,000,000 µs at level 3" as one insert). The immediate consumer is [`metrics-rs`](https://github.com/metrics-rs/metrics): its `Histogram::record_many(value, count)` currently drains into the DDSketch-backed `Summary` as a loop of single adds, and a companion PR making `record_many` O(1) end to end needs this primitive.

## Change

`DDSketch::add_with_count(v, count)` records `v` as if `add(v)` had been called `count` times, in constant time. It exposes the existing `pub(crate) Store::add_count` through the sketch API, with the corresponding `zero_count`/`sum`/min/max handling. `add(v)` now delegates to `add_with_count(v, 1)`; `Store::add` was left with no callers and removed (`Store` is not exported).

Naming and semantics mirror DataDog's Java (`accept(value, count)`) and Go (`AddWithCount`) implementations, restricted to integer counts to match this crate's integer bins. A count of zero is a no-op.

Exactness: repeated `add` and one `add_with_count` produce identical bins, count, min, max, and quantiles — the collapse logic depends only on keys, never on count magnitude. The `sum` is more accurate weighted, since `v * count` avoids N accumulated float roundings.

Two enabling fixes ride along, both made reachable by weighted adds: `quantile()` computes ranks from the internal u64 total and `count()` saturates instead of truncating on 32-bit targets (a single `add_with_count` can now push totals past 2^32), and `repeat_n` (Rust 1.82+) is replaced with `repeat().take()` so the crate keeps compiling for downstream consumers on older toolchains (metrics-rs declares MSRV 1.71.1).

## Tests

- `add_with_count(v, n)` ≡ n × `add(v)` across positive, negative, and zero-threshold paths (count/min/max/sum/quantiles)
- count = 0 is a no-op
- weighted adds through store collapse (tight bin limit, wide dynamic range) match repeated adds exactly
- existing suite passing unchanged
